### PR TITLE
jIAuthDriver : link broken

### DIFF
--- a/authentification/drivers.gtw
+++ b/authentification/drivers.gtw
@@ -136,7 +136,7 @@ password_crypt_function = "md5"
 
 ===== Class =====
 
-Class driver is more a multiverse driver compared to Db driver. You just have to assign a class to it, in which you do... what you want! Except that it has to implement [[refclass:auth_driver/jIAuthDriverClass|jIAuthDriverClass interface]]. This class is considered as a business classes and therefore should be located in //classes// folder of one of your modules.
+Class driver is more a multiverse driver compared to Db driver. You just have to assign a class to it, in which you do... what you want! Except that it has to implement [[refclass:auth_driver/jIAuthDriver|jIAuthDriver interface]]. This class is considered as a business classes and therefore should be located in //classes// folder of one of your modules.
 
 //auth.plugin.ini.php// would declare :
 


### PR DESCRIPTION
For the class driver, the name and the link of the interface is jIAuthDriver, and not jIAuthDriverClass
